### PR TITLE
Amazon Linux 2

### DIFF
--- a/amazonlinux-vagrant/Dockerfile
+++ b/amazonlinux-vagrant/Dockerfile
@@ -1,19 +1,8 @@
-FROM amazonlinux:2017.03
+FROM amazonlinux:2
 
 # Install required packages
-RUN yum -y install yum-plugin-fastestmirror findutils \
-    && yum clean all \
-    && find /usr/share \
-        -type f \
-        -regextype posix-extended \
-        -regex '.*\.(jpg|png)$' \
-        -delete \
-    && rm -rf /etc/ld.so.cache \
-    && rm -rf /sbin/sln \
-    && rm -rf /usr/{{lib,share}/locale,share/{man,doc,info,cracklib,i18n},{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive} \
-    && rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/*
-
-RUN yum -y install sudo passwd unzip bzip2 cracklib-dicts python27-setuptools openssh-clients openssh-server \
+RUN yum -y install yum-plugin-fastestmirror \
+    && yum -y install findutils sudo passwd unzip bzip2 tar cracklib-dicts python2-pip openssh-clients openssh-server \
     && yum clean all \
     && find /usr/share \
         -type f \
@@ -26,9 +15,7 @@ RUN yum -y install sudo passwd unzip bzip2 cracklib-dicts python27-setuptools op
     && rm -rf /{root,tmp,var/cache/{ldconfig,yum}}/*
 
 # Install supervisord
-RUN easy_install \
-    'supervisor == 3.3.1' \
-    'supervisor-stdout == 0.1.1'
+RUN pip install supervisor==3.3.1 supervisor-stdout==0.1.1
 ADD files/supervisord.conf /etc/supervisord.conf
 
 # Configure sshd
@@ -59,6 +46,11 @@ RUN sed -i \
 # Add missing file
 RUN echo 'NETWORKING=yes' > /etc/sysconfig/network
 
+# Make Ansible believe we are running systemd
+ADD files/systemctl /usr/bin/systemctl
+RUN chmod 755 /usr/bin/systemctl \
+    && mkdir /run/systemd/system
+
 EXPOSE 22
 
-CMD ["/usr/local/bin/supervisord", "--configuration=/etc/supervisord.conf"]
+CMD ["/usr/bin/supervisord", "--configuration=/etc/supervisord.conf"]

--- a/amazonlinux-vagrant/files/supervisord.conf
+++ b/amazonlinux-vagrant/files/supervisord.conf
@@ -9,7 +9,7 @@ minprocs = 200
 nodaemon = true
 
 [eventlistener:supervisor_stdout]
-command = /usr/local/bin/supervisor_stdout
+command = /usr/bin/supervisor_stdout
 buffer_size = 100
 events = PROCESS_LOG
 result_handler = supervisor_stdout:event_handler

--- a/amazonlinux-vagrant/files/systemctl
+++ b/amazonlinux-vagrant/files/systemctl
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo ActiveState=active


### PR DESCRIPTION
## Summary of changes

- Use `amazonlinux:2` as base image
- Install supervisord using pip
- Make it look like systemd is running to avoid errors in Ansible playbooks
- Combine layers 1 and 2 into one layer

## How to Test

Build the image and run it:

```bash
$ docker build -t juwaicom/amazonlinux-vagrant:2.0 .
$ docker run -d --name test juwaicom/amazonlinux-vagrant:2.0
```