### PR TITLE
Amazon Linux 2 systemd fix

### DIFF
--- a/amazonlinux-vagrant/Dockerfile
+++ b/amazonlinux-vagrant/Dockerfile
@@ -2,7 +2,18 @@ FROM amazonlinux:2
 
 # Install required packages
 RUN yum -y install yum-plugin-fastestmirror \
-    && yum -y install findutils sudo passwd unzip bzip2 tar cracklib-dicts python2-pip openssh-clients openssh-server \
+    && yum -y install \
+        findutils \
+        sudo \
+        passwd \
+        unzip \
+        bzip2 \
+        tar \
+        cracklib-dicts \
+        python2-pip \
+        openssh-clients \
+        openssh-server \
+        yum-plugin-post-transaction-actions \
     && yum clean all \
     && find /usr/share \
         -type f \
@@ -46,9 +57,11 @@ RUN sed -i \
 # Add missing file
 RUN echo 'NETWORKING=yes' > /etc/sysconfig/network
 
-# Make Ansible believe we are running systemd
+# Create dummy systemctl and make Ansible believe we are using systemd
 ADD files/systemctl /usr/bin/systemctl
-RUN chmod 755 /usr/bin/systemctl \
+ADD files/systemctl /usr/bin/systemctl.docker
+RUN chmod 755 /usr/bin/systemctl /usr/bin/systemctl.docker \
+    && echo 'systemd:update:cp /usr/bin/systemctl.docker /usr/bin/systemctl' > /etc/yum/post-actions/post.action \
     && mkdir /run/systemd/system
 
 EXPOSE 22

--- a/amazonlinux-vagrant/files/supervisord.conf
+++ b/amazonlinux-vagrant/files/supervisord.conf
@@ -16,13 +16,13 @@ result_handler = supervisor_stdout:event_handler
 startsecs = 0
 
 [unix_http_server]
-file = /tmp/supervisor.sock
+file = /var/run/supervisor.sock
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl = unix:///tmp/supervisor.sock
+serverurl = unix:///var/run/supervisor.sock
 
 [include]
 files = /etc/supervisor.d/*.conf


### PR DESCRIPTION
## Summary of changes

- Replace systemctl executable in yum post hook. Otherwise systemctl comes back when installing packages that depend on systemd and systemd has a new version in repository.
- Move supervisor sock file to match change in https://github.com/juwai/ansible-role-supervisor/pull/9

## How to Test

```bash
$ docker build -t juwaicom/amazonlinux-vagrant:2.0 .
```