### PR TITLE
Composer with sudo

### DIFF
--- a/amazonlinux-vagrant/Dockerfile
+++ b/amazonlinux-vagrant/Dockerfile
@@ -64,6 +64,13 @@ RUN chmod 755 /usr/bin/systemctl /usr/bin/systemctl.docker \
     && echo 'systemd:update:cp /usr/bin/systemctl.docker /usr/bin/systemctl' > /etc/yum/post-actions/post.action \
     && mkdir /run/systemd/system
 
+# Forward ssh agent when using sudo
+RUN echo 'Defaults env_keep+=SSH_AUTH_SOCK' > /etc/sudoers.d/ssh_auth_sock \
+    && chmod 440 /etc/sudoers.d/ssh_auth_sock
+
+# Disable host key checking for github.com
+ADD files/ssh-config /root/.ssh/config
+
 EXPOSE 22
 
 CMD ["/usr/bin/supervisord", "--configuration=/etc/supervisord.conf"]

--- a/amazonlinux-vagrant/files/ssh-config
+++ b/amazonlinux-vagrant/files/ssh-config
@@ -1,0 +1,2 @@
+Host github.com
+    StrictHostKeyChecking no


### PR DESCRIPTION
## Summary of changes

- Forward ssh agent when using sudo
- Disable host key checking for root user when connecting to github

This is to allow running composer without permission or blocking issues

## How to Test

Test the host key checking:

```bash
$ docker build -t juwaicom/amazonlinux-vagrant:2.0 .
$ docker run -it juwaicom/amazonlinux-vagrant:2.0 bash
# ssh -T git@github.com
```

Testing the ssh agent forwarding is a little more complicated. I tested it with Vagrant/Ansible.