### PR TITLE
Add g++ to npm image

### DIFF
--- a/amazonlinux-npm/Dockerfile
+++ b/amazonlinux-npm/Dockerfile
@@ -18,6 +18,7 @@ FROM amazonlinux:2
 RUN yum -y install yum-plugin-fastestmirror \
     && yum -y install \
         git \
+        gcc-c++ \
     && yum clean all \
     && find /usr/share \
         -type f \


### PR DESCRIPTION
## Summary of changes

Add g++ to npm image

## How to Test

```bash
$ cd amazonlinux-npm/
$ docker build -t amazonlinux-npm:8.1 --build-arg VERSION=8.17.0 .
```